### PR TITLE
비정상적 시위 참여 인증 패턴 검출 기능 및 테스트 케이스 추가

### DIFF
--- a/src/main/java/com/on/eye/api/config/security/AnonymousIdGenerator.java
+++ b/src/main/java/com/on/eye/api/config/security/AnonymousIdGenerator.java
@@ -23,7 +23,7 @@ public class AnonymousIdGenerator {
     @Value("${hash.secret-key}")
     private String secretKey;
 
-    public String generateAnonymousUserId(Long userId, Long protestId) {
+    public String generateAnonymousUserId(Long userId) {
         try {
             SecretKeySpec keySpec =
                     new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8), HAMAC_SHA256);
@@ -31,7 +31,7 @@ public class AnonymousIdGenerator {
             Mac mac = Mac.getInstance(HAMAC_SHA256);
             mac.init(keySpec);
 
-            String message = String.format("%d:%d", protestId, userId);
+            String message = userId.toString();
             byte[] hash = mac.doFinal(message.getBytes(StandardCharsets.UTF_8));
 
             return HexFormat.of().formatHex(hash);

--- a/src/main/java/com/on/eye/api/domain/ParticipantsVerification.java
+++ b/src/main/java/com/on/eye/api/domain/ParticipantsVerification.java
@@ -20,7 +20,7 @@ public class ParticipantsVerification {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "protest_id", nullable = false, updatable = false)
     private Protest protest;
 

--- a/src/main/java/com/on/eye/api/domain/Protest.java
+++ b/src/main/java/com/on/eye/api/domain/Protest.java
@@ -47,6 +47,9 @@ public class Protest {
     @OneToOne(mappedBy = "protest", cascade = CascadeType.ALL, orphanRemoval = true)
     private ProtestVerification protestVerification;
 
+    @OneToMany(mappedBy = "protest", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ParticipantsVerification> participantsVerifications;
+
     @Column(nullable = false)
     @Min(1)
     @Max(5000000)

--- a/src/main/java/com/on/eye/api/dto/VerificationHistory.java
+++ b/src/main/java/com/on/eye/api/dto/VerificationHistory.java
@@ -1,0 +1,11 @@
+package com.on.eye.api.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record VerificationHistory(
+        String anonymousUserId,
+        Long protestId,
+        BigDecimal latitude,
+        BigDecimal longitude,
+        LocalDateTime verifiedAt) {}

--- a/src/main/java/com/on/eye/api/exception/AbnormalMovementPatternException.java
+++ b/src/main/java/com/on/eye/api/exception/AbnormalMovementPatternException.java
@@ -1,0 +1,13 @@
+package com.on.eye.api.exception;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class AbnormalMovementPatternException extends CustomCodeException {
+    public static final CustomCodeException EXCEPTION = new AbnormalMovementPatternException();
+
+    private AbnormalMovementPatternException() {
+        super(ProtestErrorCode.ABNORMAL_MOVEMENT_PATTERN);
+        log.error(ProtestErrorCode.ABNORMAL_MOVEMENT_PATTERN.getMessage());
+    }
+}

--- a/src/main/java/com/on/eye/api/exception/ProtestErrorCode.java
+++ b/src/main/java/com/on/eye/api/exception/ProtestErrorCode.java
@@ -14,8 +14,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ProtestErrorCode implements BaseErrorCode {
     PROTEST_NOT_FOUND(NOT_FOUND, "PROTEST_400_1", "해당 id의 시위 정보를 조회할 수 없습니다"),
+    LOCATION_NOT_FOUND(NOT_FOUND, "PROTEST_400_2", "해당 id의 위치 정보를 조회할 수 없습니다"),
     DUPLICATED_VERIFICATION(CONFLICT, "PROTEST_409_1", "한개의 시위에 중복 인증은 불가능합니다"),
-    OUT_OF_VALID_PROTEST_RANGE(UNPROCESSABLE_ENTITY, "PROTEST_422_1", "유효한 시위 참여인증 범위 밖에 있습니다");
+    OUT_OF_VALID_PROTEST_RANGE(UNPROCESSABLE_ENTITY, "PROTEST_422_1", "유효한 시위 참여인증 범위 밖에 있습니다"),
+    ABNORMAL_MOVEMENT_PATTERN(UNPROCESSABLE_ENTITY, "PROTEST_422_2", "불가능한 이동속도 인증입니다");
 
     private final Integer status;
     private final String code;

--- a/src/main/java/com/on/eye/api/exception/protest/LocationNotFoundException.java
+++ b/src/main/java/com/on/eye/api/exception/protest/LocationNotFoundException.java
@@ -1,0 +1,16 @@
+package com.on.eye.api.exception.protest;
+
+import com.on.eye.api.exception.CustomCodeException;
+import com.on.eye.api.exception.ProtestErrorCode;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class LocationNotFoundException extends CustomCodeException {
+    public static final CustomCodeException EXCEPTION = new LocationNotFoundException();
+
+    private LocationNotFoundException() {
+        super(ProtestErrorCode.LOCATION_NOT_FOUND);
+        log.error(ProtestErrorCode.LOCATION_NOT_FOUND.getMessage());
+    }
+}

--- a/src/main/java/com/on/eye/api/repository/LocationRepository.java
+++ b/src/main/java/com/on/eye/api/repository/LocationRepository.java
@@ -1,6 +1,5 @@
 package com.on.eye.api.repository;
 
-import java.math.BigDecimal;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -22,22 +21,6 @@ public interface LocationRepository extends JpaRepository<Location, Long> {
             nativeQuery = true)
     Optional<Location> findMostSimilarLocation(
             @Param("searchName") String searchName, @Param("threshold") double threshold);
-
-    @Query(
-            value =
-                    """
-                                 SELECT earth_distance(
-                                     ll_to_earth(:userLat, :userLng),
-                                     ll_to_earth(l.latitude, l.longitude)
-                                     )
-                                 FROM locations l
-                                 WHERE l.id = :locationId
-                            """,
-            nativeQuery = true)
-    Double calculateDistance(
-            @Param("userLat") BigDecimal userLat,
-            @Param("userLng") BigDecimal userLng,
-            @Param("locationId") Long locationId);
 
     @Query(
             """

--- a/src/main/java/com/on/eye/api/repository/ParticipantVerificationRepository.java
+++ b/src/main/java/com/on/eye/api/repository/ParticipantVerificationRepository.java
@@ -1,12 +1,29 @@
 package com.on.eye.api.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.on.eye.api.domain.ParticipantsVerification;
+import com.on.eye.api.dto.VerificationHistory;
 
 public interface ParticipantVerificationRepository
         extends JpaRepository<ParticipantsVerification, Long> {
     List<ParticipantsVerification> getParticipantsVerificationByProtest_Id(Long protestId);
+
+    @Query(
+            """
+                    SELECT new com.on.eye.api.dto.VerificationHistory(:anonUserId, p.id, l.latitude, l.longitude, pv.verifiedAt)  FROM ParticipantsVerification pv
+                                JOIN pv.protest p
+                                JOIN p.locationMappings plm
+                                JOIN plm.location l
+                            WHERE pv.anonymousUserId = :anonUserId and pv.protest.startDateTime >= :today
+                            ORDER BY pv.verifiedAt DESC
+                            LIMIT 1
+                    """)
+    Optional<VerificationHistory> getVerifiedParticipantsByDateTime(
+            LocalDateTime today, String anonUserId);
 }

--- a/src/main/java/com/on/eye/api/repository/ProtestRepository.java
+++ b/src/main/java/com/on/eye/api/repository/ProtestRepository.java
@@ -9,15 +9,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.on.eye.api.domain.Protest;
-import com.on.eye.api.domain.ProtestStatus;
 
 public interface ProtestRepository extends JpaRepository<Protest, Long> {
-    // 상태별 시위 목록 조회
-    List<Protest> findByStatus(ProtestStatus status);
-
-    List<Protest> findByStartDateTimeBetween(
-            LocalDateTime startDateTimeAfter, LocalDateTime startDateTimeBefore);
-
     List<Protest> findByStartDateTimeAfter(LocalDateTime startDateTime);
 
     @Query("SELECT p FROM Protest p LEFT JOIN FETCH p.organizer WHERE p.id = :protestId")

--- a/src/main/java/com/on/eye/api/util/GeoUtils.java
+++ b/src/main/java/com/on/eye/api/util/GeoUtils.java
@@ -1,0 +1,39 @@
+package com.on.eye.api.util;
+
+import java.math.BigDecimal;
+
+public class GeoUtils {
+    public static double haversineDistance(
+            BigDecimal startLatitude,
+            BigDecimal startLongitude,
+            BigDecimal endLatitude,
+            BigDecimal endLongitude) {
+        // 지구 반경 (미터)
+        final double EARTH_RADIUS_METERS = 6371000;
+
+        // 위도와 경도 차이를 라디안으로 변환
+        double latitudeDiffRadians =
+                Math.toRadians(endLatitude.doubleValue() - startLatitude.doubleValue());
+        double longitudeDiffRadians =
+                Math.toRadians(endLongitude.doubleValue() - startLongitude.doubleValue());
+
+        // 시작점과 종료점의 위도를 라디안으로 변환
+        double startLatRadians = Math.toRadians(startLatitude.doubleValue());
+        double endLatRadians = Math.toRadians(endLatitude.doubleValue());
+
+        // 하버사인 공식의 중간 계산값
+        double haversineFormula =
+                Math.sin(latitudeDiffRadians / 2) * Math.sin(latitudeDiffRadians / 2)
+                        + Math.cos(startLatRadians)
+                                * Math.cos(endLatRadians)
+                                * Math.sin(longitudeDiffRadians / 2)
+                                * Math.sin(longitudeDiffRadians / 2);
+
+        // 두 지점 사이의 구면 거리 (라디안)
+        double angularDistanceRadians =
+                2 * Math.atan2(Math.sqrt(haversineFormula), Math.sqrt(1 - haversineFormula));
+
+        // 실제 지표면 거리 (미터)
+        return EARTH_RADIUS_METERS * angularDistanceRadians;
+    }
+}

--- a/src/test/java/com/on/eye/api/ProtestParticipationVerificationTest.java
+++ b/src/test/java/com/on/eye/api/ProtestParticipationVerificationTest.java
@@ -2,18 +2,12 @@ package com.on.eye.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 
 import java.math.BigDecimal;
-import java.time.Duration;
-import java.time.Instant;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
@@ -34,7 +28,6 @@ import com.on.eye.api.exception.DuplicateVerificationException;
 import com.on.eye.api.exception.OutOfValidProtestRangeException;
 import com.on.eye.api.repository.LocationRepository;
 import com.on.eye.api.repository.ParticipantVerificationRepository;
-import com.on.eye.api.repository.ProtestRepository;
 import com.on.eye.api.repository.ProtestVerificationRepository;
 import com.on.eye.api.service.ProtestService;
 
@@ -48,48 +41,20 @@ class ProtestParticipationVerificationTest {
             LoggerFactory.getLogger(ProtestParticipationVerificationTest.class);
     @Autowired private ProtestService protestService;
 
-    @Autowired private ProtestRepository protestRepository;
-
     @Autowired private LocationRepository locationRepository;
     @Autowired private ParticipantVerificationRepository participantVerificationRepository;
 
     private Long testProtestId;
     private Location testLocation;
     private static final Long TEST_USER_ID = 1L;
-    private List<Long> testUserIds;
-    private final int CONCURRENT_USERS = 100000;
-    private final int THREADS = 10;
-    private ExecutorService executorService;
     private final AtomicBoolean cleanUpExecuted = new AtomicBoolean(false);
 
-    private static final int WARMUP_USERS = 10;
-    private static final int TEST_USERS = 150000;
-    private static final int THREAD_POOL_SIZE = 200;
-    private static final Duration EXPECTED_RESPONSE_TIME = Duration.ofMillis(500);
-
-    private List<Duration> responseTimes;
-    private List<String> performanceIssues;
     @Autowired private ProtestVerificationRepository protestVerificationRepository;
 
     @BeforeAll
     void setUp() {
-        // shutdown hook
-        Runtime.getRuntime()
-                .addShutdownHook(
-                        new Thread(
-                                () -> {
-                                    if (!cleanUpExecuted.get()) {
-                                        performCleanup();
-                                    }
-                                }));
-
         // 테스트용 사용자 인증 컨텍스트 설정
         setUpSecurityContext();
-        createTestUsers();
-        executorService = Executors.newFixedThreadPool(THREADS);
-
-        responseTimes = new CopyOnWriteArrayList<>();
-        performanceIssues = new CopyOnWriteArrayList<>();
     }
 
     @BeforeEach
@@ -106,7 +71,6 @@ class ProtestParticipationVerificationTest {
     @AfterAll
     void afterAll() {
         performCleanup();
-        executorService.shutdown();
     }
 
     @Test
@@ -156,264 +120,6 @@ class ProtestParticipationVerificationTest {
                 .isInstanceOf(DuplicateVerificationException.class);
     }
 
-    @Test
-    @DisplayName("동시에 여러 사용자가 시위 참여 인증 시도")
-    void concurrentParticipationVerification() throws InterruptedException {
-        // Given
-        CountDownLatch startLatch = new CountDownLatch(1);
-        CountDownLatch completionLatch = new CountDownLatch(CONCURRENT_USERS);
-        AtomicInteger successCount = new AtomicInteger(0);
-        AtomicInteger duplicateCount = new AtomicInteger(0);
-        List<Future<?>> futures = new ArrayList<>();
-
-        ParticipateVerificationRequest request =
-                new ParticipateVerificationRequest(
-                        testLocation.getLongitude(), testLocation.getLatitude());
-
-        // When
-        for (int i = 0; i < CONCURRENT_USERS; i++) {
-            final Long userId = testUserIds.get(i);
-            futures.add(
-                    executorService.submit(
-                            () -> {
-                                try {
-                                    startLatch.await(); // 모든 스레드가 동시에 시작하도록 대기
-                                    setSecurityContext(userId);
-
-                                    protestService.participateVerify(testProtestId, request);
-                                    successCount.incrementAndGet();
-                                } catch (DuplicateVerificationException e) {
-                                    duplicateCount.incrementAndGet();
-                                } catch (Exception e) {
-                                    log.error("Unexpected error during verification", e);
-                                } finally {
-                                    SecurityContextHolder.clearContext();
-                                    completionLatch.countDown();
-                                }
-                            }));
-        }
-
-        // 모든 스레드 동시 시작
-        startLatch.countDown();
-
-        // 모든 작업 완료 대기
-        boolean completed = completionLatch.await(30, TimeUnit.SECONDS);
-        List<ParticipantsVerification> verifications =
-                participantVerificationRepository.getParticipantsVerificationByProtest_Id(
-                        testProtestId);
-
-        // Then
-        assertThat(completed).isTrue();
-
-        assertThat(successCount.get()).isEqualTo(CONCURRENT_USERS);
-
-        assertThat(duplicateCount.get()).isZero();
-
-        // 모든 Future 완료 확인
-        for (Future<?> future : futures) {
-            assertThat(future.isDone()).isTrue();
-        }
-    }
-
-    @Test
-    @DisplayName("동일 사용자가 여러 스레드에서 동시에 인증 시도")
-    void concurrentParticipationVerificationSameUser() throws InterruptedException {
-        // Given
-        CountDownLatch startLatch = new CountDownLatch(1);
-        CountDownLatch completionLatch = new CountDownLatch(THREADS);
-        AtomicInteger successCount = new AtomicInteger(0);
-        AtomicInteger duplicateCount = new AtomicInteger(0);
-        final Long userId = testUserIds.get(0);
-
-        ParticipateVerificationRequest request =
-                new ParticipateVerificationRequest(
-                        testLocation.getLongitude(), testLocation.getLatitude());
-
-        // When
-        for (int i = 0; i < THREADS; i++) {
-            executorService.submit(
-                    () -> {
-                        try {
-                            startLatch.await();
-                            setSecurityContext(userId);
-
-                            protestService.participateVerify(testProtestId, request);
-                            successCount.incrementAndGet();
-                        } catch (DuplicateVerificationException e) {
-                            duplicateCount.incrementAndGet();
-                        } catch (Exception e) {
-                            log.error("Unexpected error during verification", e);
-                        } finally {
-                            SecurityContextHolder.clearContext();
-                            completionLatch.countDown();
-                        }
-                    });
-        }
-
-        startLatch.countDown();
-        completionLatch.await(30, TimeUnit.SECONDS);
-
-        // Then
-        assertThat(successCount.get()).isEqualTo(1);
-        assertThat(duplicateCount.get()).isEqualTo(THREADS - 1);
-    }
-
-    @Test
-    @Order(1)
-    @DisplayName("시스템 웜업")
-    void warmupSystem() throws InterruptedException {
-        runConcurrentRequests(WARMUP_USERS);
-        // 웜업 데이터는 성능 측정에서 제외
-        responseTimes.clear();
-    }
-
-    @Test
-    @Order(2)
-    @DisplayName("동시 사용자 처리 성능 테스트")
-    void concurrentUsersPerformanceTest() throws InterruptedException {
-        // When
-        Instant testStart = Instant.now();
-        runConcurrentRequests(TEST_USERS);
-        Duration totalTestTime = Duration.between(testStart, Instant.now());
-
-        // Then
-        analyzePerformance(totalTestTime);
-
-        // verifed_num 확인. 이거 안같은듯?
-        Integer verifiedNum =
-                protestVerificationRepository.findByProtestId(testProtestId).getVerifiedNum();
-        assertThat(verifiedNum).isEqualTo(TEST_USERS);
-    }
-
-    private void runConcurrentRequests(int userCount) throws InterruptedException {
-        CountDownLatch startLatch = new CountDownLatch(1);
-        CountDownLatch completionLatch = new CountDownLatch(userCount);
-        AtomicInteger activeThreads = new AtomicInteger(0);
-
-        // Submit tasks
-        for (int i = 0; i < userCount; i++) {
-            final Long userId = (long) i;
-            executorService.submit(
-                    () -> {
-                        try {
-                            startLatch.await();
-                            activeThreads.incrementAndGet();
-
-                            Instant start = Instant.now();
-                            executeVerification(userId);
-                            Duration responseTime = Duration.between(start, Instant.now());
-                            responseTimes.add(responseTime);
-
-                            // 스레드 풀 포화 상태 체크
-                            checkThreadPoolSaturation(activeThreads.get());
-
-                        } catch (Exception e) {
-                            log.error("Error during verification: ", e);
-                            performanceIssues.add("Error in request: " + e.getMessage());
-                        } finally {
-                            activeThreads.decrementAndGet();
-                            completionLatch.countDown();
-                        }
-                    });
-        }
-
-        startLatch.countDown();
-        completionLatch.await(30, TimeUnit.SECONDS);
-    }
-
-    private void executeVerification(Long userId) {
-        setSecurityContext(userId);
-        try {
-            ParticipateVerificationRequest request =
-                    new ParticipateVerificationRequest(
-                            testLocation.getLongitude(), testLocation.getLatitude());
-            protestService.participateVerify(testProtestId, request);
-        } finally {
-            SecurityContextHolder.clearContext();
-        }
-    }
-
-    private void checkThreadPoolSaturation(int currentActiveThreads) {
-        if (currentActiveThreads >= THREAD_POOL_SIZE) {
-            performanceIssues.add(
-                    String.format(
-                            "Thread pool saturation detected: %d active threads",
-                            currentActiveThreads));
-        }
-    }
-
-    private void analyzePerformance(Duration totalTestTime) {
-        if (responseTimes.isEmpty()) {
-            fail("No response times recorded");
-        }
-
-        // 응답 시간 통계 계산
-        Duration maxResponseTime =
-                responseTimes.stream().max(Duration::compareTo).orElse(Duration.ZERO);
-        Duration minResponseTime =
-                responseTimes.stream().min(Duration::compareTo).orElse(Duration.ZERO);
-        Duration avgResponseTime = calculateAverageResponseTime();
-        Duration p95ResponseTime = calculatePercentileResponseTime(95);
-        Duration p99ResponseTime = calculatePercentileResponseTime(99);
-
-        // 성능 메트릭 로깅
-        log.info("Performance Test Results:");
-        log.info("Total Test Time: {} ms", totalTestTime.toMillis());
-        log.info("Average Response Time: {} ms", avgResponseTime.toMillis());
-        log.info("95th Percentile Response Time: {} ms", p95ResponseTime.toMillis());
-        log.info("99th Percentile Response Time: {} ms", p99ResponseTime.toMillis());
-        log.info("Min Response Time: {} ms", minResponseTime.toMillis());
-        log.info("Max Response Time: {} ms", maxResponseTime.toMillis());
-
-        if (!performanceIssues.isEmpty()) {
-            log.warn("Performance Issues Detected:");
-            performanceIssues.forEach(log::warn);
-        }
-
-        // Assertions
-        assertAll(
-                () ->
-                        assertTrue(
-                                avgResponseTime.compareTo(EXPECTED_RESPONSE_TIME) <= 0,
-                                "Average response time exceeds expected time"),
-                () ->
-                        assertTrue(
-                                p95ResponseTime.compareTo(EXPECTED_RESPONSE_TIME.multipliedBy(2))
-                                        <= 0,
-                                "95th percentile response time is too high"),
-                () ->
-                        assertTrue(
-                                maxResponseTime.compareTo(EXPECTED_RESPONSE_TIME.multipliedBy(5))
-                                        <= 0,
-                                "Maximum response time is too high"),
-                () ->
-                        assertTrue(
-                                performanceIssues.isEmpty(),
-                                "Performance issues detected: "
-                                        + String.join(", ", performanceIssues)));
-    }
-
-    private Duration calculateAverageResponseTime() {
-        long totalMillis = responseTimes.stream().mapToLong(Duration::toMillis).sum();
-        return Duration.ofMillis(totalMillis / responseTimes.size());
-    }
-
-    private Duration calculatePercentileResponseTime(double percentile) {
-        List<Duration> sortedTimes = new ArrayList<>(responseTimes);
-        sortedTimes.sort(Duration::compareTo);
-        int index = (int) Math.ceil(percentile / 100.0 * sortedTimes.size()) - 1;
-        return sortedTimes.get(index);
-    }
-
-    private void setSecurityContext(Long userId) {
-        UsernamePasswordAuthenticationToken authentication =
-                new UsernamePasswordAuthenticationToken(
-                        userId.toString(),
-                        "credentials",
-                        Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")));
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-    }
-
     private void setUpSecurityContext() {
         UsernamePasswordAuthenticationToken authentication =
                 new UsernamePasswordAuthenticationToken(
@@ -450,13 +156,6 @@ class ProtestParticipationVerificationTest {
         testProtestId = protestIds.get(0);
     }
 
-    private void createTestUsers() {
-        testUserIds = new ArrayList<>();
-        for (long i = 1; i <= CONCURRENT_USERS; i++) {
-            testUserIds.add(i);
-        }
-    }
-
     void cleanUp() {
         log.info("Cleaning up...");
         List<ParticipantsVerification> verifications =
@@ -464,7 +163,6 @@ class ProtestParticipationVerificationTest {
                         testProtestId);
         participantVerificationRepository.deleteAll(verifications);
 
-        //        protestRepository.deleteById(testProtestId);
         locationRepository.delete(testLocation);
         log.info("Cleanup complete.");
     }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,84 @@
+server:
+  servlet:
+    context-path: /api             # ???? ??? ??? ??
+spring:
+  config:
+    import: optional:file:.env[.properties]
+  application:
+    name: api
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-name: kakao
+            client-id: ${KAKAO_CLIENT_ID}
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            redirect-uri: "${BASE_URL}/api/login/oauth2/code/kakao"
+            scope:
+              - profile_nickname
+              - profile_image
+        #              - account_email
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+  datasource:
+    hikari:
+      driver-class-name: org.postgresql.Driver
+      connection-timeout: '20000'
+      maximum-pool-size: '4'
+      minimum-idle: '1'
+      connection-test-query: SELECT 1
+    password: ${DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+    username: ${DB_USERNAME}
+    url: ${DB_URL}
+  jpa:
+    show-sql: 'true'
+    properties:
+      hibernate:
+        format_sql: 'true'
+        use_sql_comments: 'true'
+        default_batch_fetch_size: '100'
+    open-in-view: false
+    hibernate:
+      ddl-auto: validate
+    defer-datasource-initialization: 'false'
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    locations: classpath:db/migrations
+auth:
+  jwt:
+    secret-key: ${JWT_SECRET_KEY}
+    expiration: 360000000 # 100 day
+    refresh-expiration: 604800000 # 1 week
+app:
+  oauth2:
+    redirectUri: "${FRONT_BASE_URL}/oauth2/callback"
+
+hash:
+  secret-key: ${HASH_SECRET_KEY}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+
+logging:
+  config: classpath:log4j2-test.xml
+  level:
+    web: DEBUG
+    com.zaxxer.hikari.HikariConfig: DEBUG
+    com.zaxxer.hikari: TRACE
+    org.springframework.orm.jpa: DEBUG
+    org.springframework.transaction: DEBUG
+    org.springframework.security: DEBUG
+    org.springframework.web.client.RestTemplate: DEBUG
+    org.springframework.security.web.FilterChainProxy: DEBUG
+    org.springframework.security.web.authentication.OAuth2LoginAuthenticationFilter: TRACE


### PR DESCRIPTION
## 변경사항
- 시속 60km의 속도로 연달은 시위 참여 인증 시도는 부정인증으로 처리
  - 이를 위해 ParticipantsVerifixation(시위인증 기록) 테이블에서 익명 유저 id 해싱 로직에서 protestId를 제거해, userId 당 일관적이고 고유한 해시값이 사용되도록 함. 익명성은 약해졌지만, 한 유저의 인증 이력을 조회해 부정인증 패턴을 잡을 수 있게 되었음
- 두 위경도 간의 거리 계산 : postgresql의 earh_diatance 모듈 → 하버사인 공식을 활용한 app 로직으로 변경
  - 위치 기반 쿼리를 하는 것이 아니기 때문에, 굳이 DB에 접근해서 계산할 필요가 없음
  - earth_distance 모듈도 하버사인 공식처럼 지구를 완전한 구라고 가정하기에 기존 방식과 오차 차이 적음
- 비정상 이동 인증 로직 테스트 코드 추가
- 시위 참여 테스트 코드 과정 중 생산된 데이터 clean up 로직 추가
- 하지만 아직 clean up 되지 않는 데이터(organization, location) 있음. 허나 이는 DB에 기존 데이터가 존재하면 새롭게 추가되는 데이터는 아니기에 굳이 삭제하지 않음

## 부족한 부분
- 시위 인증 로직에서, 시위가 진행 중일 때만 인증이 가능해야 하나 아직 해당 로직이 없음