### PR TITLE
응원 배치 처리 추가

### DIFF
--- a/src/main/java/com/on/eye/api/cheer/repository/CheerRepository.java
+++ b/src/main/java/com/on/eye/api/cheer/repository/CheerRepository.java
@@ -1,6 +1,7 @@
 package com.on.eye.api.cheer.repository;
 
 import java.util.List;
+import java.util.Map;
 
 import com.on.eye.api.cheer.dto.CheerStat;
 
@@ -27,4 +28,11 @@ public interface CheerRepository {
      * @return 시위 ID별 응원 수 통계
      */
     List<CheerStat> getTodayCheerStats();
+
+    /**
+     * 여러개 시위의 응원 수 한번에 증가
+     *
+     * @param pendingCheers 시위 ID를 key로 증가시킬 응원 수를 value로 가지는 Map
+     */
+    void incrementCheerCountBatch(Map<Long, Integer> pendingCheers);
 }

--- a/src/main/java/com/on/eye/api/cheer/repository/JpaCheerRepository.java
+++ b/src/main/java/com/on/eye/api/cheer/repository/JpaCheerRepository.java
@@ -2,6 +2,7 @@ package com.on.eye.api.cheer.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
@@ -65,5 +66,16 @@ public class JpaCheerRepository implements CheerRepository {
                                 new CheerStat(
                                         cheerCount.getProtestId(), cheerCount.getCheerCount()))
                 .toList();
+    }
+
+    @Override
+    @Transactional
+    public void incrementCheerCountBatch(Map<Long, Integer> pendingCheers) {
+        for (Map.Entry<Long, Integer> entry : pendingCheers.entrySet()) {
+            Long protestId = entry.getKey();
+            Integer increment = entry.getValue();
+
+            protestCheerCountRepository.incrementCheerCountBatch(protestId, increment);
+        }
     }
 }

--- a/src/main/java/com/on/eye/api/cheer/repository/ProtestCheerCountRepository.java
+++ b/src/main/java/com/on/eye/api/cheer/repository/ProtestCheerCountRepository.java
@@ -27,4 +27,9 @@ public interface ProtestCheerCountRepository extends JpaRepository<ProtestCheerC
     @Query(
             "UPDATE ProtestCheerCount pc SET pc.cheerCount = pc.cheerCount + 1 WHERE pc.protestId = :protestId")
     Integer incrementCheerCount(@Param("protestId") Long protestId);
+
+    @Modifying
+    @Query(
+            "UPDATE ProtestCheerCount pc SET pc.cheerCount = pc.cheerCount + ?2 WHERE pc.protestId = ?1")
+    void incrementCheerCountBatch(Long protestId, Integer increment);
 }

--- a/src/main/java/com/on/eye/api/cheer/repository/RedisCheerCacheRepository.java
+++ b/src/main/java/com/on/eye/api/cheer/repository/RedisCheerCacheRepository.java
@@ -2,6 +2,7 @@ package com.on.eye.api.cheer.repository;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -66,6 +67,16 @@ public class RedisCheerCacheRepository implements CheerCacheRepository {
         if (keys.isEmpty()) return;
 
         redisTemplate.delete(keys);
+    }
+
+    @Override
+    public void incrementCheerCountBatch(Map<Long, Integer> pendingCheers) {
+        for (Map.Entry<Long, Integer> entry : pendingCheers.entrySet()) {
+            String key = "protest:cheer:" + entry.getKey();
+            Integer increment = entry.getValue();
+
+            redisTemplate.opsForValue().increment(key, increment);
+        }
     }
 
     private String generateCheerCountKeyWithNullCheck(Long protestId) {

--- a/src/main/java/com/on/eye/api/cheer/service/CheerServiceImpl.java
+++ b/src/main/java/com/on/eye/api/cheer/service/CheerServiceImpl.java
@@ -1,7 +1,14 @@
 package com.on.eye.api.cheer.service;
 
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import com.on.eye.api.cheer.repository.JpaCheerRepository;
+import com.on.eye.api.cheer.repository.RedisCheerCacheRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import com.on.eye.api.cheer.dto.CheerStat;
@@ -15,22 +22,70 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class CheerServiceImpl implements CheerService {
 
-    private final CheerRepository redisCheerCacheRepository;
+    private final CheerRepository cheerRepository;
+
+    private final ConcurrentHashMap<Long, Integer> pendingCheers = new ConcurrentHashMap<>();
+    private final AtomicInteger pendingCheerCount = new AtomicInteger(0);
+
+    private static final int BATCH_THRESHOLD = 1000;
+    private static final long FLUSH_INTERVAL = 3000;
+
+    @Autowired
+    public CheerServiceImpl(JpaCheerRepository jpaCheerRepository,
+                            RedisCheerCacheRepository redisCheerCacheRepository,
+                            @Value("${cheer.repository.type:redis}") String repositoryType) {
+
+        this.cheerRepository = "jpa".equals(repositoryType) ? jpaCheerRepository : redisCheerCacheRepository;
+    }
 
     @Override
     public CheerStat cheerProtest(Long protestId) {
-        Integer newCount = redisCheerCacheRepository.incrementCheerCount(protestId);
-        return new CheerStat(protestId, newCount);
+
+        pendingCheers.compute(protestId, (id, count) -> count == null ? 1 : count + 1);
+
+        pendingCheerCount.incrementAndGet();
+
+        if (isFlushNeed()) {
+            flushPendingCheers();
+        }
+
+        return new CheerStat(protestId, 0);
     }
 
     @Override
     public CheerStat getCheerStat(Long protestId) {
-        Integer cheerCount = redisCheerCacheRepository.getCheerCount(protestId);
+        Integer cheerCount = cheerRepository.getCheerCount(protestId);
         return new CheerStat(protestId, cheerCount);
     }
 
     @Override
     public List<CheerStat> getTodayCheerStats() {
-        return redisCheerCacheRepository.getTodayCheerStats();
+        return cheerRepository.getTodayCheerStats();
+    }
+
+    @Scheduled(fixedRate = FLUSH_INTERVAL)
+    public void scheduledFlush() {
+        if (hasPendingCheers()) {
+            flushPendingCheers();
+        }
+    }
+
+    private synchronized void flushPendingCheers() {
+        if (pendingCheers.isEmpty()) {
+            return;
+        }
+
+        cheerRepository.incrementCheerCountBatch(pendingCheers);
+
+        pendingCheers.clear();
+        pendingCheerCount.set(0);
+    }
+
+    private boolean isFlushNeed() {
+        return pendingCheerCount.get() >= BATCH_THRESHOLD;
+    }
+
+    private boolean hasPendingCheers() {
+        return pendingCheerCount.get() >= 0;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -102,3 +102,7 @@ logging:
     org.springframework.web.client.RestTemplate: DEBUG
     org.springframework.security.web.FilterChainProxy: DEBUG
     org.springframework.security.web.authentication.OAuth2LoginAuthenticationFilter: TRACE
+
+cheer:
+  repository:
+    type: jpa


### PR DESCRIPTION
## 주요 변경점
1. cheerService에 배치 처리 도입
    + 관련 Repository 코드들도 함께 수정되었습니다.
    + BATCH_THRESHOLD, FLUSH_INTERVAL 상수로 배치 처리할 요청의 수, 시간을 조절할 수 있습니다.
2. cheerRepository 외부 주입
    + cheerService에서 사용할 Repository를 application.yml에서 지정해줄 수 있습니다.