### PR TITLE
시위 생성 방식 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,57 +5,111 @@
     - 부정 참여 인증 방지
         - 비정상적 이동패턴
         - 중복인증
+- 시위 응원하기 기능
 
 ### 진행기간 및 프로젝트 참여 인원
 
-- 개발기간: 2024.12 ~ 진행 중
-- 5인 프로젝트(FE: 2명, BE: 1명, DevOps: 1명, Data: 1명)
+- 개발기간: 2024.12 ~ 2025.04
+- 4인 프로젝트(FE: 2명, BE: 2명)
 
 ### 서비스 아키텍쳐
-
-<img src="https://github.com/user-attachments/assets/872a6af2-40e9-4133-a001-e534c3b17a31" width="750"/>
+<img src="https://github.com/user-attachments/assets/f36de375-2493-4019-8100-ae9c8c60fce8" width="750"/>
 
 ### 서비스 화면
 
 <img src="https://github.com/user-attachments/assets/25ff8eea-c82e-48d1-a98b-191e0002449f" width="300"/>
-<img src="https://github.com/user-attachments/assets/f360dc6d-eabb-4287-b5b2-25c28162e0b3" width="300"/>
+<img src="https://github.com/user-attachments/assets/606066b2-c590-4f76-95ec-f739d9674271" width="300"/>
 
 ### 프로젝트 목표
 
 - 서비스 주제와 관련된 문제 해결에 필요한 적정기술 선택 경험
-- 스트레스 테스트를 통해 수집한 근거에 기반한 성능 개선 경험
-- 대규모 유저에게 메세지 발송을 위한 메세지큐 적용 경험
+- 성능 테스트를 통해 수집한 근거에 기반한 성능 개선 경험
 - Agile 방법론 적용 시 개발 효용성 증진을 위한 CI/CD 적용 경험
 - 리팩토링에 열려있으며 신뢰도 높은 코드 작성을 위한 테스트 코드 작성
-- AWS 비용 절약을 위해 하나의 인스턴스에 집중된 프로세스들을 안정적으로 관리하기 위한 도커 사용 환경 격리
-
-### 주요 기능
-
-- 시위 정보 CRUD
-    - 정확한 시위 장소 위경도 관리를 위한 시위장소 텍스트 검색 유사도 기반 관리 로직 적용
-- 현재 위치 기반 시위 참여 인증
-    - 시위 참여 신고 인원 기준 참여인증 유효 거리 계산
-    - 부정 인증 방지 로직 적용
-- JWT 기반 OAuth(카카오) 회원가입/로그인
 
 ### 트러블 슈팅
 
-**시위 참여인증 부정 방지**
+**[K6를 사용한 성능 테스트로 병목 식별 및 개선(대규모 트래픽 간접 경험)]**
 
-- 시위 참여 인증 수에 따라 client에서 시각적으로 강조되는 시위가 달라짐. 따라서 시위 인증에 대한 높은 정확도와 신뢰도가 요구되었음
-- 중복인증 방지(시위 인증 멱등성 유지)를 위해 인증 정보 저장 테이블 생성
-    - 시위 Id와 Hashing한 User Id를 Unique key로 설정해 시위 인증 고유성 확보
-- 비정상적 인증 패턴 확인
-    - 당일 시위 참여 인증 기록이 있는 유저가 추가 인증을 한 경우, 기존 인증 기록과 새 인증 요청의 시간과 거리를 각각 비교.
-    - 인간의 이동속도 상 불가능한 패턴의 인증시도 시 무효 처리
+문제 상황
 
-**PostgreSQL 텍스트 검색 extension(pg_bigm)을 사용한 시위장소 관리 최적화**
+- 많은 부하가 예상되는 [실시간 시위 응원하기] 기능에 대한 성능 검증 부족
 
-- 서울시 경찰청 일일 집회신고 자료를 크롤링 해 시위장소를 비롯한 정보를 수집 중. 하지만 데이터에 아래와 같은 문제가 있었음
-    - 실제 지명과 다른 존재하지 않는 장소명 사용 e.g., 송현공원(신고장소) 앞 인도 → 열린 송현 녹지 광장(실제 장소) 앞 인도
-    - 오타 발생 e.g., 명둉역 4번출구(오타) → 명동역 4번출구(실제 장소)
-- LIKE 연산자로는 위와 같은 미묘한 차이를 잡아낼 수 없음
-- 이를 해결하기 위해 Fuzzy search 기능을 제공하는 PostgreSQL의 pg_bigm을 사용
-- 유사도 값을 튜닝하여 잘못된 지명이 입력되더라도, 기존 저장된 올바른 지명과 위경도를 사용하도록 함
+성능 테스트 준비
+- Docker를 사용해 Test Server용 Mini PC에  성능 테스트 환경 구성 (Spring, Prometheus, Grafana, K6)
+    - 배포 instance인 t3.small과 유사한 환경 제약을 걸기 위해 Spring instance에 2 Core, 2G RAM의 제약을 설정
+    - 환경 구성 시간 대폭 절약
+
+[실시간 시위 응원하기] 기능 성능 테스트 시나리오
+- 유저가 1초에 3회 씩 랜덤한 시위를 응원하고, Polling 방식 3초에 1번씩 응원 수를 조회. 유저 1명 당 RPS = 3.3회
+
+병목 개선 및 성과
+- 과도한 Hikaricp Connection Pool Size로 인한 병목 개선
+    - 10개 → 2개로 조절
+    - 요청 실패율 47% → 4% (91.5% 개선)
+- 과도한 Tomcat Thread Pool Size로 인한 병목 개선
+    - 200개 → 10개로 조절
+    - 요청 실패율 4% → 0.6% (85% 개선)
+- DB 병목 제거
+    - 응원 데이터에 Redis Cache 적용
+    - 요청 실패율 0.6% → 0%
+    - 최대 RPS 17개 → 2560개 (150배 증가)
+    - 평균 요청 응답시간 4.5s → 1.24s (72.4% 개선)
+
+결과 요약
+
+병목 개선 전
+
+<img src="https://github.com/user-attachments/assets/9bd002ce-cdc7-4952-9f21-64658403823b" width="300" />
+
+병목 개선 후
+
+<img src="https://github.com/user-attachments/assets/9d258969-c31b-4e2e-9d48-2af1b4e4a72c" width="300" />
+
+
+
+**[Production Server 환경과 동일한 Staging Server 환경 구축]**
+
+문제 상황
+- 안정적인 E2E 서비스 테스트를 위한 환경 부족
+- 실제 유저가 있는 서비스이기 때문에 Production 배포 전 철저한 실제 사용 테스트 환경이 필요
+- Localhost 환경은 Production과 다르기 때문에 신뢰할 수 없음
+- SSL 인증서 미적용, 하드웨어 자원 차이 등
+
+개선 및 성과
+
+개선
+- 홈 서버 Mini PC를 Staging 서버로 환경 구축
+- DDNS, NAT Forwarding 설정을 통해 동료들의 Staging에서 동작 중인 서비스 접근 허용
+- Production 환경과 동일한 Staging 환경 구축
+- 실제 환경과 동일하게 Nginx에 SSL 인증서 적용
+- Docker를 사용해 Production 환경과의 차이를 제거. 하드웨어 제약 설정까지 추가
+
+성과
+- Production에서 기능 장애 발생 횟수 0회 기록
+
+**[리팩토링을 통한 코드 결합도 및 가독성 개선]**
+
+문제 상황
+- 동료가 이해하기 어려운 난잡한 코드.  method 이해에 최고 20m 소요
+- Transactional Script pattern + Anemic Domain model의  사용으로 단일 메소드가 하나 이상의 책임을 수행
+- 비즈니스 로직이 캡슐화 되어있지 않고 script 방식 실행
+- Domain간 분리 미적용
+- 하나의 Service Class에 5개의 Domain Repository class 사용
+
+개선 및 성과
+
+개선
+- Rich Domain Model 적용
+    - 비즈니스 로직을 각 Domain Class로 분산
+- GoF Design Pattern 적용
+    - Facade Pattern, Aggregate Pattern 적용
+- Layer 중심 모듈 구조 → Domain 중심 모듈구조로 변경
+
+성과
+- method 이해에 최고 20m → 5m 소요(75% 개선)
+- 평균 method 길이 62% 감소
+- 코드의 단일책임원칙 준수 정도 증가
+- Layer 중심 이해 → Domain 중심 이해
 
 ![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/dev-4-team/eye-on-backend?utm_source=oss&utm_medium=github&utm_campaign=dev-4-team%2Feye-on-backend&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)

--- a/src/main/java/com/on/eye/api/cheer/controller/CheerRestController.java
+++ b/src/main/java/com/on/eye/api/cheer/controller/CheerRestController.java
@@ -1,15 +1,13 @@
 package com.on.eye.api.cheer.controller;
 
-import java.util.List;
-
+import com.on.eye.api.cheer.dto.CheerStat;
+import com.on.eye.api.cheer.service.CheerService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import com.on.eye.api.cheer.dto.CheerStat;
-import com.on.eye.api.cheer.service.CheerService;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.util.List;
 
 /**
  * 응원 관련 REST API 컨트롤러 HTTP 요청을 통한 응원 기능을 제공. Polling vs WebSocket 비교 or WebSocket 불가능한 상황 대처 위해 생성
@@ -19,7 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class CheerRestController {
-    private final CheerService cheerDbService;
+    private final CheerService cheerCacheService;
 
     /**
      * 특정 시위의 응원 수를 조회
@@ -29,7 +27,7 @@ public class CheerRestController {
      */
     @GetMapping("/{protestId}")
     public ResponseEntity<CheerStat> getCheerStat(@PathVariable Long protestId) {
-        CheerStat stats = cheerDbService.getCheerStat(protestId);
+        CheerStat stats = cheerCacheService.getCheerStat(protestId);
         log.debug("응원 통계 조회 - 시위 ID: {}, 응원 수: {}", protestId, stats.cheerCount());
         return ResponseEntity.ok(stats);
     }
@@ -41,7 +39,7 @@ public class CheerRestController {
      */
     @GetMapping
     public ResponseEntity<List<CheerStat>> getAllCheerStat() {
-        List<CheerStat> statsList = cheerDbService.getAllCheerStats();
+        List<CheerStat> statsList = cheerCacheService.getAllCheerStats();
         log.debug("모든 시위 응원 통계 조회 - 시위 개수: {}", statsList.size());
         return ResponseEntity.ok(statsList);
     }
@@ -54,7 +52,7 @@ public class CheerRestController {
      */
     @PostMapping("/{protestId}")
     public ResponseEntity<CheerStat> cheerProtest(@PathVariable Long protestId) {
-        Integer cheerCount = cheerDbService.cheerProtest(protestId);
+        Integer cheerCount = cheerCacheService.cheerProtest(protestId);
         log.debug("REST API 응원 요청 - 시위 ID: {}, 응원 후 카운트: {}", protestId, cheerCount);
 
         CheerStat stats = new CheerStat(protestId, cheerCount);

--- a/src/main/java/com/on/eye/api/location/service/LocationService.java
+++ b/src/main/java/com/on/eye/api/location/service/LocationService.java
@@ -1,9 +1,5 @@
 package com.on.eye.api.location.service;
 
-import java.util.List;
-
-import org.springframework.stereotype.Service;
-
 import com.on.eye.api.location.dto.LocationDto;
 import com.on.eye.api.location.dto.ProtestLocationDto;
 import com.on.eye.api.location.entity.Location;
@@ -12,16 +8,17 @@ import com.on.eye.api.location.entity.ProtestLocationMappings;
 import com.on.eye.api.location.error.exception.LocationNotFoundException;
 import com.on.eye.api.location.repository.LocationRepository;
 import com.on.eye.api.protest.entity.Protest;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class LocationService {
     private final LocationRepository locationRepository;
-    private static final double SIMILARITY_THRESHOLD = 0.35;
 
     public ProtestLocationMappings assignLocationMappings(
             Protest protest, List<LocationDto> locationDtos) {
@@ -41,7 +38,7 @@ public class LocationService {
 
     private Location getOrCreateLocation(LocationDto locationDto) {
         return locationRepository
-                .findMostSimilarLocation(locationDto.name(), SIMILARITY_THRESHOLD)
+                .findByName(locationDto.name())
                 .orElseGet(() -> locationRepository.save(Location.from(locationDto)));
     }
 

--- a/src/main/java/com/on/eye/api/protest/dto/ProtestResponse.java
+++ b/src/main/java/com/on/eye/api/protest/dto/ProtestResponse.java
@@ -26,7 +26,7 @@ public record ProtestResponse(
 
         return ProtestResponse.builder()
                 .id(protest.getId())
-                .title(organizer != null ? organizer.title() : protest.getTitle())
+                .title(protest.getTitle())
                 .description(organizer != null ? organizer.description() : null)
                 .organizer(organizer != null ? organizer.name() : null)
                 .startDateTime(protest.getStartDateTime())

--- a/src/main/java/com/on/eye/api/protest/entity/Protest.java
+++ b/src/main/java/com/on/eye/api/protest/entity/Protest.java
@@ -55,12 +55,12 @@ public class Protest extends BaseTimeEntity {
     private final List<ParticipantsVerification> participantsVerifications = new ArrayList<>();
 
     @Column(nullable = false)
-    @Min(1)
+    @Min(0)
     @Max(5000000)
     private Integer declaredParticipants;
 
     @Column(nullable = false)
-    private Integer radius = 500;
+    private Integer radius = 10;
 
     @Builder
     public Protest(

--- a/src/main/resources/db/migrations/V5__alter__declared_participants.sql
+++ b/src/main/resources/db/migrations/V5__alter__declared_participants.sql
@@ -1,0 +1,6 @@
+ALTER TABLE protests
+    DROP CONSTRAINT protests_declared_participants_check;
+
+ALTER TABLE protests
+    ADD CONSTRAINT protests_declared_participants_check
+        CHECK ((declared_participants <= 5000000) AND (declared_participants >= 0));


### PR DESCRIPTION
- 최소 신고인원 1명 → 0명 변경
- 위차 생성 시 위치명의 유사도 사용 → 위치명과 직접적인 일치로 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 시위 응답에서 제목이 항상 시위의 제목으로 설정되도록 수정되었습니다.
- **기능 개선**
	- 시위의 최소 참가자 수가 0명으로 완화되었습니다.
	- 시위 반경의 기본값이 500에서 10으로 축소되었습니다.
	- 장소 이름 매칭 시 유사도 기준 대신 정확한 이름 일치만 사용하도록 변경되었습니다.
- **데이터베이스**
	- 시위 참가자 수 컬럼의 허용 범위가 0~5,000,000명으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->